### PR TITLE
Fixed the package name in the README.md as it was referencing the old one in pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ A Python package that helps Data and Analytics engineers trigger run on demand j
 ## How to Use
 
 ### Install the Plugin 
-Pypi package: https://pypi.org/project/apache-airflow-microsoft-fabric-plugin/
+Pypi package: https://pypi.org/project/apache-airflow-microsoft-fabric/
 ```bash 
-pip install apache-airflow-microsoft-fabric-plugin
+pip install apache-airflow-microsoft-fabric
 ```
 
 ### Prerequisities


### PR DESCRIPTION
Fixed the pypi package reference in README.md and also the pip install command as apache-airflow-microsoft-fabric-plugin is the old package