### PR TITLE
Introducing Fabric Secret Backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ version = "0.1.0"
 requires-python = ">=3.8"
 dependencies = [
     "requests",
+    "azure-identity",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
-version = "0.0.9"
+version = "0.1.0"
 requires-python = ">=3.8"
 dependencies = [
     "requests",

--- a/src/airflow/providers/microsoft/fabric/get_provider_info.py
+++ b/src/airflow/providers/microsoft/fabric/get_provider_info.py
@@ -48,4 +48,9 @@ def get_provider_info():
                 "plugin-class": "airflow.providers.microsoft.fabric.plugins.fabric_status_plugin.FabricStatusPlugin",
             }
         ],
+        "secrets-backends": [
+            {
+                "python-class": "airflow.providers.microsoft.fabric.secrets.fabric_secret_backend.FabricSecretBackend",
+            }
+        ],
     }

--- a/src/airflow/providers/microsoft/fabric/get_provider_info.py
+++ b/src/airflow/providers/microsoft/fabric/get_provider_info.py
@@ -49,8 +49,6 @@ def get_provider_info():
             }
         ],
         "secrets-backends": [
-            {
-                "python-class": "airflow.providers.microsoft.fabric.secrets.fabric_secret_backend.FabricSecretBackend",
-            }
+            "airflow.providers.microsoft.fabric.secrets.fabric_secret_backend.FabricSecretBackend",
         ],
     }

--- a/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection.py
+++ b/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection.py
@@ -108,7 +108,9 @@ class MSFabricRestConnection(BaseHook):
             self.log.error("Connection '%s' has no extra configuration", conn_id)
             raise AirflowException(
                 f"Connection '{conn_id}' missing extra configuration. "
-                "Please configure the required parameters for the chosen auth type."
+                "Please configure the required parameters for the chosen auth type "
+                "(for example, for auth_type='spn' you typically need tenantId, clientId, and clientSecret). "
+                "Refer to the Microsoft Fabric provider documentation for details on each auth type's requirements."
             )
 
         available_params = list(self.conn.extra_dejson.keys())

--- a/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection.py
+++ b/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection.py
@@ -9,6 +9,7 @@ from tenacity import AsyncRetrying, retry_if_exception_type, stop_after_attempt,
 
 from airflow.providers.microsoft.fabric.hooks.connection.http_client import HttpClient
 from airflow.providers.microsoft.fabric.hooks.connection.rest_connection_spn import MSFabricRestConnectionSPN
+from airflow.providers.microsoft.fabric.hooks.connection.rest_connection_token import MSFabricRestConnectionToken
 
 from wtforms import StringField, PasswordField
 from flask_appbuilder.fieldwidgets import BS3PasswordFieldWidget, BS3TextFieldWidget
@@ -17,6 +18,7 @@ from flask_babel import gettext
 
 AUTH_CLASSES = {
     "spn": MSFabricRestConnectionSPN,
+    "token": MSFabricRestConnectionToken,
     # Future: "pat": MSFabricRestConnectionPAT,
     # Future: "msi": MSFabricRestConnectionMSI,
 }
@@ -106,17 +108,14 @@ class MSFabricRestConnection(BaseHook):
             self.log.error("Connection '%s' has no extra configuration", conn_id)
             raise AirflowException(
                 f"Connection '{conn_id}' missing extra configuration. "
-                "Please configure tenantId, clientId, and clientSecret."
+                "Please configure the required parameters for the chosen auth type."
             )
 
         available_params = list(self.conn.extra_dejson.keys())
         self.log.debug("Available connection parameters for '%s': %s", conn_id, available_params)
         
-        # Stick with spn for now due to lack of support for select fields in 2.10.5
-        # extras = self.conn.extra_dejson
-        # auth_type = extras.get("auth_type", "spn").lower()
-        auth_type = "spn"
-        
+        extras = self.conn.extra_dejson
+        auth_type = extras.get("auth_type", "spn").lower()
         self.log.debug("Using auth_type: %s for connection '%s'", auth_type, conn_id)
         
         auth_class = AUTH_CLASSES.get(auth_type)

--- a/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection_token.py
+++ b/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection_token.py
@@ -27,7 +27,7 @@ class MSFabricRestConnectionToken:
 
         self._access_token: str = ""
         self._expires_at: float = 0.0
-        self._expiry_buffer: int = 300  # seconds
+        self._expiry_buffer: float = 0.0
 
         self._load_token(conn)
 
@@ -89,13 +89,23 @@ class MSFabricRestConnectionToken:
         self._access_token = token
         self._expires_at = float(expires_at)
 
+        # Derive our buffer from the secret backend's buffer so the backend
+        # always evicts its cache *before* we consider the token stale.
+        # Using half the backend buffer guarantees: backend_buffer > token_buffer.
+        backend_buffer = extras.get("expiryBufferSeconds")
+        if backend_buffer is not None:
+            self._expiry_buffer = float(backend_buffer) / 2
+        elif self._expiry_buffer == 0.0:
+            self._expiry_buffer = 60.0  # safe default
+
         self.log.debug(
-            "Loaded pre-minted token for connection '%s' (expires %s).",
+            "Loaded pre-minted token for connection '%s' (expires %s, backend buffer %.0fs, token buffer %.0fs).",
             self.connection_id,
             self._fmt_ts(self._expires_at),
+            float(backend_buffer) if backend_buffer is not None else 0.0,
+            self._expiry_buffer,
         )
 
-    #TODO: self._expiry_buffer should always be higher than the SecretBackend buffer, or we may not refresh and say it is still invalid. 
     def _is_token_valid(self) -> bool:
         return time.time() < (self._expires_at - self._expiry_buffer)
 

--- a/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection_token.py
+++ b/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection_token.py
@@ -1,0 +1,105 @@
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+from airflow.exceptions import AirflowException
+from airflow.hooks.base import BaseHook
+from airflow.models import Connection
+
+
+class MSFabricRestConnectionToken:
+    """
+    Authentication handler for pre-minted access tokens supplied by a
+    secrets backend (e.g. ``FabricSecretBackend``).
+
+    The token and its expiry are read from ``Connection.extra_dejson``.
+    When the token is close to expiry the handler re-fetches the Connection
+    via ``BaseHook.get_connection`` which triggers the secrets backend to
+    supply a fresh token.
+    """
+
+    auth_type = "token"
+
+    def __init__(self, conn: Connection) -> None:
+        self.log = logging.getLogger(__name__)
+        self.connection_id = conn.conn_id
+
+        self._access_token: str = ""
+        self._expires_at: float = 0.0
+        self._expiry_buffer: int = 300  # seconds
+
+        self._load_token(conn)
+
+    # ------------------------------------------------------------------
+    # Public API (same contract as MSFabricRestConnectionSPN)
+    # ------------------------------------------------------------------
+
+    def get_access_token(self, scope: str) -> str:
+        """
+        Return the pre-minted access token.
+
+        *scope* is accepted for interface compatibility but is not used
+        because the token was already minted for a specific audience by the
+        Fabric API.
+        """
+        if self._is_token_valid():
+            self.log.debug(
+                "Using cached pre-minted token for connection '%s' (expires %s).",
+                self.connection_id,
+                self._fmt_ts(self._expires_at),
+            )
+            return self._access_token
+
+        # Token expired – re-fetch the Connection (triggers secrets backend)
+        self.log.info(
+            "Pre-minted token for connection '%s' expired or within buffer. "
+            "Re-fetching connection from secrets backend.",
+            self.connection_id,
+        )
+        conn = BaseHook.get_connection(self.connection_id)
+        self._load_token(conn)
+
+        if not self._is_token_valid():
+            raise AirflowException(
+                f"Re-fetched token for connection '{self.connection_id}' is already "
+                "expired. Check the Fabric secret-store API."
+            )
+
+        return self._access_token
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_token(self, conn: Connection) -> None:
+        extras = conn.extra_dejson
+        token = extras.get("accessToken")
+        expires_at = extras.get("expiresAt")
+
+        if not token:
+            raise AirflowException(
+                f"Connection '{self.connection_id}' missing 'accessToken' in extras."
+            )
+        if expires_at is None:
+            raise AirflowException(
+                f"Connection '{self.connection_id}' missing 'expiresAt' in extras."
+            )
+
+        self._access_token = token
+        self._expires_at = float(expires_at)
+
+        self.log.debug(
+            "Loaded pre-minted token for connection '%s' (expires %s).",
+            self.connection_id,
+            self._fmt_ts(self._expires_at),
+        )
+
+    def _is_token_valid(self) -> bool:
+        return time.time() < (self._expires_at - self._expiry_buffer)
+
+    @staticmethod
+    def _fmt_ts(epoch: float) -> str:
+        return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )

--- a/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection_token.py
+++ b/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection_token.py
@@ -95,6 +95,7 @@ class MSFabricRestConnectionToken:
             self._fmt_ts(self._expires_at),
         )
 
+    #TODO: self._expiry_buffer should always be higher than the SecretBackend buffer, or we may not refresh and say it is still invalid. 
     def _is_token_valid(self) -> bool:
         return time.time() < (self._expires_at - self._expiry_buffer)
 

--- a/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection_token.py
+++ b/src/airflow/providers/microsoft/fabric/hooks/connection/rest_connection_token.py
@@ -60,13 +60,23 @@ class MSFabricRestConnectionToken:
         conn = BaseHook.get_connection(self.connection_id)
         self._load_token(conn)
 
-        if not self._is_token_valid():
-            raise AirflowException(
-                f"Re-fetched token for connection '{self.connection_id}' is already "
-                "expired. Check the Fabric secret-store API."
-            )
+        if self._is_token_valid():
+            return self._access_token
 
-        return self._access_token
+        # Token is within buffer but not truly expired — use it with a warning
+        if time.time() < self._expires_at:
+            self.log.warning(
+                "Re-fetched token for connection '%s' is within the expiry buffer "
+                "but still valid (expires %s). Fabric may have returned the same token.",
+                self.connection_id,
+                self._fmt_ts(self._expires_at),
+            )
+            return self._access_token
+
+        raise AirflowException(
+            f"Re-fetched token for connection '{self.connection_id}' is already "
+            "expired. Check the Fabric secret-store API."
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
+++ b/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
@@ -129,7 +129,8 @@ class FabricSecretBackend(BaseSecretsBackend):
             response = requests.get(
                 url,
                 headers={"Authorization": f"Bearer {azure_token.token}"},
-                timeout=30
+                timeout=30,
+                json={},
             )
             elapsed = time.monotonic() - start
 

--- a/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
+++ b/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
@@ -61,7 +61,7 @@ class FabricSecretBackend(BaseSecretsBackend):
     default)::
 
         FABRIC_SECRET_BACKEND_API_URL=https://<fabric-api-host>
-        FABRIC_API_SCOPE=API scope to be used
+        FABRIC_SECRET_BACKEND_API_SCOPE=API scope to be used
     """
 
     def __init__(
@@ -78,11 +78,11 @@ class FabricSecretBackend(BaseSecretsBackend):
 
         self._expiry_buffer_seconds = expiry_buffer_seconds
 
-        self._api_scope = api_scope or os.environ.get("FABRIC_API_SCOPE")
+        self._api_scope = api_scope or os.environ.get("FABRIC_SECRET_BACKEND_API_SCOPE")
         if not self._api_scope:
             raise AirflowException(
                 "FabricSecretBackend requires 'api_scope' or the "
-                "FABRIC_API_SCOPE environment variable to be set."
+                "FABRIC_SECRET_BACKEND_API_SCOPE environment variable to be set."
             )
         
         self._api_base_url = api_base_url or os.environ.get("FABRIC_SECRET_BACKEND_API_URL")

--- a/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
+++ b/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
@@ -222,6 +222,7 @@ class FabricSecretBackend(BaseSecretsBackend):
                     "auth_type": "token",
                     "accessToken": access_token,
                     "expiresAt": expires_at,
+                    "expiryBufferSeconds": self._expiry_buffer_seconds,
                 }
             ),
         )

--- a/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
+++ b/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import re
+import requests
 import time
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple
@@ -10,7 +11,12 @@ from airflow.exceptions import AirflowException
 from airflow.models.connection import Connection
 from airflow.secrets import BaseSecretsBackend
 
+from azure.identity import DefaultAzureCredential
+
 log = logging.getLogger(__name__)
+
+# Scope required to call back into Fabric APIs - Specific to Fabric Airflow Job. 
+FABRIC_API_SCOPE = "64e9913a-54b9-4fdb-b4bb-b8e22fa6a37e/.defAPault"
 
 _GUID_REGEX = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
@@ -20,11 +26,14 @@ _GUID_REGEX = re.compile(
 class FabricSecretBackend(BaseSecretsBackend):
     """
     Airflow secrets backend that fetches pre-minted access tokens from a
-    Microsoft Fabric secret-store API when the connection ID is a GUID.
+    Microsoft Fabric secret-store API. 
+    
+    THIS IS NOT INTENDED FOR USE OUTSIDE OF FABRIC AIRFLOW JOBS.
 
-    For non-GUID connection IDs the lookup is skipped (returns ``None``) so
-    that remaining backends in the chain (e.g. environment variables, Airflow
-    metadata DB) can handle them.
+    Connections in Fabric are represented as a GUID - will use that as a 
+    lookup pattern filter. For non-GUID connection IDs the lookup is 
+    skipped (returns ``None``) so that remaining backends in the chain 
+    (e.g. environment variables, Airflow metadata DB) can handle them.
 
     Configuration (airflow.cfg)::
 
@@ -32,8 +41,9 @@ class FabricSecretBackend(BaseSecretsBackend):
         backend = airflow.providers.microsoft.fabric.secrets.fabric_secret_backend.FabricSecretBackend
         backend_kwargs = {"expiry_buffer_seconds": 300}
 
-    Environment variables:
-        FABRIC_SECRET_BACKEND_API_URL  -- base URL of the Fabric credential API.
+    Environment variables
+        FABRIC_SECRET_BACKEND_API_URL  -- base URL of the Fabric API.
+    TODO: in future move this to a configuration parameter:
     """
 
     def __init__(
@@ -110,12 +120,9 @@ class FabricSecretBackend(BaseSecretsBackend):
         log.debug("Fetching credential from Fabric API: %s", url)
 
         try:
-            from azure.identity import DefaultAzureCredential
-            import requests
-
             credential = DefaultAzureCredential()
             azure_token = credential.get_token(
-                "64e9913a-54b9-4fdb-b4bb-b8e22fa6a37e/.default"
+                FABRIC_API_SCOPE
             )
 
             response = requests.get(

--- a/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
+++ b/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
@@ -15,9 +15,6 @@ from azure.identity import DefaultAzureCredential
 
 log = logging.getLogger(__name__)
 
-# Scope required to call back into Fabric APIs - Specific to Fabric Airflow Job. 
-FABRIC_API_SCOPE = "64e9913a-54b9-4fdb-b4bb-b8e22fa6a37e/.default"
-
 _GUID_REGEX = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
@@ -25,36 +22,76 @@ _GUID_REGEX = re.compile(
 
 class FabricSecretBackend(BaseSecretsBackend):
     """
-    Airflow secrets backend that fetches pre-minted access tokens from a
-    Microsoft Fabric secret-store API. 
-    
     THIS IS NOT INTENDED FOR USE OUTSIDE OF FABRIC AIRFLOW JOBS.
 
-    Connections in Fabric are represented as a GUID - will use that as a 
-    lookup pattern filter. For non-GUID connection IDs the lookup is 
-    skipped (returns ``None``) so that remaining backends in the chain 
-    (e.g. environment variables, Airflow metadata DB) can handle them.
+    Airflow secrets backend that fetches pre-minted access tokens 
+    from a Microsoft Fabric connections API.  
 
-    Configuration (airflow.cfg)::
+    Connections in Fabric are represented as a GUID — the GUID is used as a
+    lookup key.  For non-GUID connection IDs the lookup is skipped (returns
+    ``None``) so that remaining backends in the chain (e.g. environment
+    variables, Airflow metadata DB) can handle them.
+
+    Setup
+    -----
+    **airflow.cfg**::
 
         [secrets]
         backend = airflow.providers.microsoft.fabric.secrets.fabric_secret_backend.FabricSecretBackend
-        backend_kwargs = {"expiry_buffer_seconds": 300}
+        backend_kwargs = {
+            "api_base_url": "https://<fabric-api-host>",
+            "api_scope": "5d13f7d7-0567-429c-9880-320e9555e5fc/.default",
+            "expiry_buffer_seconds": 300
+        }
 
-    Environment variables
-        FABRIC_SECRET_BACKEND_API_URL  -- base URL of the Fabric API.
-    TODO: in future move this to a configuration parameter:
+    **Environment variable overrides** (useful in containerised / Kubernetes
+    deployments where airflow.cfg is not easy to edit).  All constructor
+    parameters can be passed as a JSON string via
+    ``AIRFLOW__SECRETS__BACKEND_KWARGS``::
+
+        AIRFLOW__SECRETS__BACKEND=airflow.providers.microsoft.fabric.secrets.fabric_secret_backend.FabricSecretBackend
+        AIRFLOW__SECRETS__BACKEND_KWARGS={
+            "api_base_url": "https://<fabric-api-host>",
+            "api_scope": "API SCOPE TO BE USED",
+            "expiry_buffer_seconds": 300
+        }
+
+    Alternatively, ``api_base_url`` and ``api_scope`` can be supplied via
+    dedicated environment variables (``expiry_buffer_seconds`` will use its
+    default)::
+
+        FABRIC_SECRET_BACKEND_API_URL=https://<fabric-api-host>
+        FABRIC_API_SCOPE=API scope to be used
+
     """
 
     def __init__(
         self,
         expiry_buffer_seconds: int = 300,
+        api_scope: Optional[str] = None,
+        api_base_url: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        self._expiry_buffer_seconds = expiry_buffer_seconds
+
         # Cache: conn_id -> (Connection, expires_at_epoch)
         self._cache: Dict[str, Tuple[Connection, float]] = {}
+
+        self._expiry_buffer_seconds = expiry_buffer_seconds
+
+        self._api_scope = api_scope or os.environ.get("FABRIC_API_SCOPE")
+        if not self._api_scope:
+            raise AirflowException(
+                "FabricSecretBackend requires 'api_scope' or the "
+                "FABRIC_API_SCOPE environment variable to be set."
+            )
+        
+        self._api_base_url = api_base_url or os.environ.get("FABRIC_SECRET_BACKEND_API_URL")
+        if not self._api_base_url:
+            raise AirflowException(
+                "FabricSecretBackend requires 'api_base_url' or the "
+                "FABRIC_SECRET_BACKEND_API_URL environment variable to be set."
+            )
 
     # ------------------------------------------------------------------
     # Public API (BaseSecretsBackend contract)
@@ -109,21 +146,12 @@ class FabricSecretBackend(BaseSecretsBackend):
 
     def _fetch_and_cache(self, conn_id: str) -> Optional[Connection]:
         """Call the Fabric credential API, build a Connection, and cache it."""
-        api_base_url = os.environ.get("FABRIC_SECRET_BACKEND_API_URL")
-        if not api_base_url:
-            log.error("FABRIC_SECRET_BACKEND_API_URL environment variable is not set.")
-            raise AirflowException(
-                "FABRIC_SECRET_BACKEND_API_URL is required for FabricSecretBackend."
-            )
-
-        url = f"{api_base_url.rstrip('/')}/connections/{conn_id}"
+        url = f"{self._api_base_url.rstrip('/')}/connections/{conn_id}"
         log.debug("Fetching credential from Fabric API: %s", url)
 
         try:
             credential = DefaultAzureCredential()
-            azure_token = credential.get_token(
-                FABRIC_API_SCOPE
-            )
+            azure_token = credential.get_token(self._api_scope)
 
             start = time.monotonic()
             response = requests.get(

--- a/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
+++ b/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
@@ -1,0 +1,233 @@
+import json
+import logging
+import os
+import re
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+from airflow.exceptions import AirflowException
+from airflow.models.connection import Connection
+from airflow.secrets import BaseSecretsBackend
+
+log = logging.getLogger(__name__)
+
+_GUID_REGEX = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+class FabricSecretBackend(BaseSecretsBackend):
+    """
+    Airflow secrets backend that fetches pre-minted access tokens from a
+    Microsoft Fabric secret-store API when the connection ID is a GUID.
+
+    For non-GUID connection IDs the lookup is skipped (returns ``None``) so
+    that remaining backends in the chain (e.g. environment variables, Airflow
+    metadata DB) can handle them.
+
+    Configuration (airflow.cfg)::
+
+        [secrets]
+        backend = airflow.providers.microsoft.fabric.secrets.fabric_secret_backend.FabricSecretBackend
+        backend_kwargs = {"expiry_buffer_seconds": 300}
+
+    Environment variables:
+        FABRIC_SECRET_BACKEND_API_URL  -- base URL of the Fabric credential API.
+    """
+
+    def __init__(
+        self,
+        expiry_buffer_seconds: int = 300,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._expiry_buffer_seconds = expiry_buffer_seconds
+        # Cache: conn_id -> (Connection, expires_at_epoch)
+        self._cache: Dict[str, Tuple[Connection, float]] = {}
+
+    # ------------------------------------------------------------------
+    # Public API (BaseSecretsBackend contract)
+    # ------------------------------------------------------------------
+
+    def get_connection(self, conn_id: str) -> Optional[Connection]:
+        """
+        Return a ``Connection`` for *conn_id* if it is a GUID that the Fabric
+        secret-store API can resolve.  Returns ``None`` otherwise so that
+        Airflow falls through to the next secrets backend.
+        """
+        if not _GUID_REGEX.match(conn_id):
+            return None
+
+        # Check the in-memory cache first
+        cached = self._get_cached(conn_id)
+        if cached is not None:
+            return cached
+
+        # Fetch from the Fabric API and cache
+        return self._fetch_and_cache(conn_id)
+
+    def get_conn_value(self, conn_id: str) -> Optional[str]:
+        """Not used - we override ``get_connection`` directly."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Cache helpers
+    # ------------------------------------------------------------------
+
+    def _get_cached(self, conn_id: str) -> Optional[Connection]:
+        if conn_id not in self._cache:
+            return None
+
+        conn, expires_at = self._cache[conn_id]
+        now = time.time()
+
+        if now >= (expires_at - self._expiry_buffer_seconds):
+            log.debug(
+                "Cached connection '%s' expired or within buffer window -- evicting.",
+                conn_id,
+            )
+            del self._cache[conn_id]
+            return None
+
+        log.debug("Returning cached connection for '%s'.", conn_id)
+        return conn
+
+    # ------------------------------------------------------------------
+    # Fabric API interaction
+    # ------------------------------------------------------------------
+
+    def _fetch_and_cache(self, conn_id: str) -> Optional[Connection]:
+        """Call the Fabric credential API, build a Connection, and cache it."""
+        api_base_url = os.environ.get("FABRIC_SECRET_BACKEND_API_URL")
+        if not api_base_url:
+            log.error("FABRIC_SECRET_BACKEND_API_URL environment variable is not set.")
+            raise AirflowException(
+                "FABRIC_SECRET_BACKEND_API_URL is required for FabricSecretBackend."
+            )
+
+        url = f"{api_base_url.rstrip('/')}/{conn_id}"
+        log.debug("Fetching credential from Fabric API: %s", url)
+
+        try:
+            from azure.identity import DefaultAzureCredential
+            import requests
+
+            credential = DefaultAzureCredential()
+            azure_token = credential.get_token(
+                "64e9913a-54b9-4fdb-b4bb-b8e22fa6a37e/.default"
+            )
+
+            response = requests.get(
+                url,
+                headers={"Authorization": f"Bearer {azure_token.token}"},
+                timeout=30,
+            )
+
+            if response.status_code == 404:
+                log.debug("Fabric API returned 404 for conn_id '%s'.", conn_id)
+                return None
+
+            response.raise_for_status()
+            payload = response.json()
+        except requests.exceptions.RequestException as exc:
+            log.error(
+                "Network error fetching credential for '%s': %s", conn_id, exc
+            )
+            raise AirflowException(
+                f"Failed to fetch credential from Fabric API for '{conn_id}': {exc}"
+            )
+
+        return self._parse_and_cache(conn_id, payload)
+
+    # ------------------------------------------------------------------
+    # Payload parsing
+    # ------------------------------------------------------------------
+
+    def _parse_and_cache(
+        self, conn_id: str, payload: Dict[str, Any]
+    ) -> Connection:
+        """
+        Extract the access token and expiry from the Fabric API response and
+        return a fully-formed ``Connection`` ready for the token auth handler.
+
+        Expected payload structure::
+
+            {
+              "datasourceDetails": {
+                "credentialDetails": {
+                  "credentials": "{\"credentialData\":[{\"name\":\"AccessToken\",\"value\":\"eyJ...\"},{\"name\":\"Expires\",\"value\":\"2026-03-08T...\"}]}"
+                }
+              }
+            }
+        """
+        try:
+            credentials_json = (
+                payload["datasourceDetails"]["credentialDetails"]["credentials"]
+            )
+            credential_data = json.loads(credentials_json)["credentialData"]
+        except (KeyError, json.JSONDecodeError, TypeError) as exc:
+            log.error(
+                "Unexpected payload structure for conn_id '%s': %s", conn_id, exc
+            )
+            raise AirflowException(
+                f"Cannot parse Fabric credential payload for '{conn_id}': {exc}"
+            )
+
+        access_token: Optional[str] = None
+        expires_str: Optional[str] = None
+
+        for item in credential_data:
+            name = item.get("name")
+            if name == "AccessToken":
+                access_token = item.get("value")
+            elif name == "Expires":
+                expires_str = item.get("value")
+
+        if not access_token:
+            raise AirflowException(
+                f"AccessToken not found in Fabric credential payload for '{conn_id}'."
+            )
+        if not expires_str:
+            raise AirflowException(
+                f"Expires not found in Fabric credential payload for '{conn_id}'."
+            )
+
+        # Parse expiry into epoch seconds
+        expires_at = self._parse_expiry(expires_str)
+
+        conn = Connection(
+            conn_id=conn_id,
+            conn_type="microsoft-fabric",
+            extra=json.dumps(
+                {
+                    "auth_type": "token",
+                    "accessToken": access_token,
+                    "expiresAt": expires_at,
+                }
+            ),
+        )
+
+        self._cache[conn_id] = (conn, expires_at)
+
+        log.info(
+            "Cached Fabric connection '%s' (expires %s).",
+            conn_id,
+            datetime.fromtimestamp(expires_at, tz=timezone.utc).strftime(
+                "%Y-%m-%d %H:%M:%S UTC"
+            ),
+        )
+        return conn
+
+    @staticmethod
+    def _parse_expiry(expires_str: str) -> float:
+        """Parse an ISO-8601 expiry string into a UTC epoch timestamp."""
+        try:
+            dt = datetime.fromisoformat(expires_str)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+        except (ValueError, TypeError) as exc:
+            raise AirflowException(
+                f"Cannot parse expiry timestamp '{expires_str}': {exc}"
+            )

--- a/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
+++ b/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
@@ -40,7 +40,7 @@ class FabricSecretBackend(BaseSecretsBackend):
         backend = airflow.providers.microsoft.fabric.secrets.fabric_secret_backend.FabricSecretBackend
         backend_kwargs = {
             "api_base_url": "https://<fabric-api-host>",
-            "api_scope": "5d13f7d7-0567-429c-9880-320e9555e5fc/.default",
+            "api_scope": "scope",
             "expiry_buffer_seconds": 300
         }
 
@@ -62,7 +62,6 @@ class FabricSecretBackend(BaseSecretsBackend):
 
         FABRIC_SECRET_BACKEND_API_URL=https://<fabric-api-host>
         FABRIC_API_SCOPE=API scope to be used
-
     """
 
     def __init__(

--- a/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
+++ b/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
@@ -16,7 +16,7 @@ from azure.identity import DefaultAzureCredential
 log = logging.getLogger(__name__)
 
 # Scope required to call back into Fabric APIs - Specific to Fabric Airflow Job. 
-FABRIC_API_SCOPE = "64e9913a-54b9-4fdb-b4bb-b8e22fa6a37e/.defAPault"
+FABRIC_API_SCOPE = "64e9913a-54b9-4fdb-b4bb-b8e22fa6a37e/.default"
 
 _GUID_REGEX = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
@@ -116,7 +116,7 @@ class FabricSecretBackend(BaseSecretsBackend):
                 "FABRIC_SECRET_BACKEND_API_URL is required for FabricSecretBackend."
             )
 
-        url = f"{api_base_url.rstrip('/')}/{conn_id}"
+        url = f"{api_base_url.rstrip('/')}/connections/{conn_id}"
         log.debug("Fetching credential from Fabric API: %s", url)
 
         try:
@@ -125,11 +125,22 @@ class FabricSecretBackend(BaseSecretsBackend):
                 FABRIC_API_SCOPE
             )
 
+            start = time.monotonic()
             response = requests.get(
                 url,
                 headers={"Authorization": f"Bearer {azure_token.token}"},
-                timeout=30,
+                timeout=30
             )
+            elapsed = time.monotonic() - start
+
+            if elapsed > 5:
+                log.warning(
+                    "Fabric API call for conn_id '%s' took %.2f seconds.", conn_id, elapsed
+                )
+            else:
+                log.info(
+                    "Fabric API call for conn_id '%s' took %.2f seconds.", conn_id, elapsed
+                )
 
             if response.status_code == 404:
                 log.debug("Fabric API returned 404 for conn_id '%s'.", conn_id)
@@ -228,11 +239,22 @@ class FabricSecretBackend(BaseSecretsBackend):
 
     @staticmethod
     def _parse_expiry(expires_str: str) -> float:
-        """Parse an ISO-8601 expiry string into a UTC epoch timestamp."""
+        """Parse an expiry string into a UTC epoch timestamp.
+
+        Supports ISO-8601 format and the ``M/D/YYYY h:mm:ss AM/PM +HH:MM``
+        format returned by some Fabric API responses.
+        """
         try:
             dt = datetime.fromisoformat(expires_str)
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=timezone.utc)
+            return dt.timestamp()
+        except (ValueError, TypeError):
+            pass
+
+        # Fallback: "3/9/2026 12:31:13 AM +00:00"
+        try:
+            dt = datetime.strptime(expires_str, "%m/%d/%Y %I:%M:%S %p %z")
             return dt.timestamp()
         except (ValueError, TypeError) as exc:
             raise AirflowException(


### PR DESCRIPTION
Added Fabric Secret Backend - did not register it yet

The secret backend will return none if the connection name is not a GUID (lookup pattern) - this will fallback to connections from the Metadata Store (default fallback). This is important to optimzie the connection lookup - or users may face timeout in DagProcessing or delays in task execution. 

Secret backend formats the payload as a connection object. Providing enough info for the rest_connection to decide what auth type to use. 

Added a new RestConnection type (RestConnectionToken) which does not try to create a token, just leverage the one provided by the connection object (from Fabric Workspace Identity).

Updated the Rest Connection to use the correct Auth implementation. 