### PR TITLE
Fix FabricSecretBackend NotImplementedError on variable/config lookups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.8"
 dependencies = [
     "requests",

--- a/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
+++ b/src/airflow/providers/microsoft/fabric/secrets/fabric_secret_backend.py
@@ -117,6 +117,24 @@ class FabricSecretBackend(BaseSecretsBackend):
         """Not used - we override ``get_connection`` directly."""
         return None
 
+    def get_variable(self, key: str) -> Optional[str]:
+        """
+        This backend only resolves Fabric connections; it does not store
+        Airflow Variables. Return ``None`` so Airflow falls through to the
+        next secrets backend cleanly instead of logging a ``NotImplementedError``
+        traceback for every Variable lookup.
+        """
+        return None
+
+    def get_config(self, key: str) -> Optional[str]:
+        """
+        This backend does not provide Airflow configuration values. Return
+        ``None`` so Airflow falls through to the next secrets backend cleanly
+        instead of logging a ``NotImplementedError`` traceback for every
+        config lookup.
+        """
+        return None
+
     # ------------------------------------------------------------------
     # Cache helpers
     # ------------------------------------------------------------------


### PR DESCRIPTION
Override get_variable and get_config to return None so Airflow falls through to the next secrets backend cleanly instead of logging a NotImplementedError traceback on every Variable/config lookup. Bump provider version to 0.1.2.