### PR TITLE
Fix native template rendering

### DIFF
--- a/.github/actions/run-airflow-dag/run_airflow_dag.py
+++ b/.github/actions/run-airflow-dag/run_airflow_dag.py
@@ -20,30 +20,64 @@ def fetch_task_logs(airflow_url, dag_id, dag_run_id, task_id, username, password
     :param password: Airflow password
     :return: Task logs as string or None if failed to fetch
     """
+    auth = HTTPBasicAuth(username, password)
+    base_url = airflow_url.rstrip('/')
     try:
         # Get task instance details first to get the try_number
-        task_instance_url = f"{airflow_url.rstrip('/')}/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}"
-        task_resp = requests.get(task_instance_url, auth=HTTPBasicAuth(username, password))
-        
+        task_instance_url = f"{base_url}/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}"
+        task_resp = requests.get(task_instance_url, auth=auth)
+
         if not task_resp.ok:
             print(f"Warning: Could not fetch task instance details for '{task_id}': {task_resp.status_code}")
             return None
-        
+
         task_data = task_resp.json()
-        try_number = task_data.get('try_number', 1)
-        
-        # Fetch logs for the task
-        logs_url = f"{airflow_url.rstrip('/')}/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/logs/{try_number}"
-        logs_resp = requests.get(logs_url, auth=HTTPBasicAuth(username, password))
-        
-        if logs_resp.ok:
-            logs_data = logs_resp.json()
-            # The logs are typically in the 'content' field
-            return logs_data.get('content', 'No log content available')
-        else:
-            print(f"Warning: Could not fetch logs for task '{task_id}': {logs_resp.status_code}")
-            return None
-            
+        # try_number reflects the latest attempt; fall back to 1 if missing/zero.
+        try_number = task_data.get('try_number') or 1
+
+        logs_url = f"{base_url}/api/v1/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/logs/{try_number}"
+
+        # The Airflow logs endpoint returns plain text unless JSON is explicitly
+        # requested via the Accept header. Request JSON and page through the
+        # full log using the continuation token so the real error/traceback
+        # (usually at the end of the log) is captured.
+        collected = []
+        token = None
+        for _ in range(50):  # safety cap to avoid an unbounded loop
+            params = {"token": token} if token else None
+            logs_resp = requests.get(
+                logs_url,
+                auth=auth,
+                headers={"Accept": "application/json"},
+                params=params,
+            )
+
+            if not logs_resp.ok:
+                print(f"Warning: Could not fetch logs for task '{task_id}': {logs_resp.status_code}")
+                break
+
+            try:
+                logs_data = logs_resp.json()
+            except ValueError:
+                # Server returned plain text instead of JSON; use it as-is.
+                text = logs_resp.text
+                if text:
+                    collected.append(text)
+                break
+
+            content = logs_data.get('content')
+            if content:
+                collected.append(content)
+
+            token = logs_data.get('continuation_token')
+            if not token:
+                break
+
+        if collected:
+            return "\n".join(collected)
+
+        return None
+
     except Exception as e:
         print(f"Warning: Exception while fetching logs for task '{task_id}': {str(e)}")
         return None
@@ -181,22 +215,17 @@ def main():
         tasks = tasks_resp.json().get("task_instances", [])
         failed = [t['task_id'] for t in tasks if t['state'] and t['state'].lower() != "success"]
         if failed:
-            # Fetch logs for the first failed task
-            first_failed_task = failed[0]
-            print(f"Fetching logs for first failed task: '{first_failed_task}'")
-            
-            task_logs = fetch_task_logs(airflow_url, dag_id, dag_run_id, first_failed_task, username, password)
-            
-            error_message = f"Some tasks did not succeed: {failed}"
-            if task_logs:
-                error_message += f"\n\nLogs for failed task '{first_failed_task}':\n"
-                error_message += "=" * 80 + "\n"
-                error_message += task_logs
-                error_message += "\n" + "=" * 80
-            else:
-                error_message += f"\n\nCould not fetch logs for failed task '{first_failed_task}'"
-            
-            fail(error_message)
+            # Print logs for every failed task. The first failed task is not
+            # necessarily the root cause (e.g. tasks that only run in scheduled
+            # runs), so emit all of them to make diagnosis reliable.
+            for task_id in failed:
+                print("\n" + "=" * 80)
+                print(f"Logs for failed task '{task_id}':")
+                print("=" * 80)
+                task_logs = fetch_task_logs(airflow_url, dag_id, dag_run_id, task_id, username, password)
+                print(task_logs if task_logs else f"(could not fetch logs for '{task_id}')")
+
+            fail(f"Some tasks did not succeed: {failed}")
 
     # Safe guard in case API returns no tasks - should not happen
     if state != "success":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     strategy:
       matrix:
         include:
+          - python-version: "3.10"
+            airflow-version: "2.10.5"
+          - python-version: "3.11"
+            airflow-version: "2.10.5"
           - python-version: "3.12"
             airflow-version: "2.10.5"
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ pip install apache-airflow-providers-microsoft-fabric
 
 ## Authentication
 
-The provider supports the following authentication methods:
+The provider supports the following authentication methods. All authentication
+values are read from the connection's **Extra** field (`Connection.extra_dejson`).
 
-| Method | Description |
-|--------|-------------|
-| **Service Principal (SPN)** | Uses `client_id` and `client_secret` for automated pipelines. |
-| **User Token** | Uses a refresh token obtained via Microsoft OAuth. |
+
+| Method | `auth_type` | Description |
+|--------|-------------|-------------|
+| **Service Principal (SPN)** | `spn` (default) | Uses `clientId` and `clientSecret` to acquire tokens via the OAuth2 client credentials flow. |
+| **Pre-minted Access Token** | `token` | Uses an access token and its expiry supplied in the connection extras, typically by a secrets backend. |
 
 ### Connection setup
 
@@ -29,11 +31,58 @@ Create a connection in Airflow with the following settings:
 |-------|-------|
 | Connection Id | Your connection name |
 | Connection Type | `microsoft-fabric` |
-| Login | Client ID of your service principal or Entra ID app |
-| Password | Client secret (SPN) or refresh token (User Token) |
-| Extra | `{"tenantId": "<tenant-id>", "auth_type": "spn"}` |
+| Extra | See the JSON examples below for your chosen `auth_type` |
 
-> For user token auth, set `auth_type` to `token` and provide a refresh token as the password.
+> The `Login`, `Password`, `Host`, `Schema`, and `Port` fields are unused and
+> hidden. In the Airflow connection UI, dedicated **Tenant ID**, **Client ID**,
+> and **Client Secret** widgets are available for the SPN flow (their values are
+> stored in the connection extras). Token auth is typically supplied
+> programmatically by a [secrets backend](#secrets-backends) or via the Airflow
+> CLI / environment variable.
+
+#### Service Principal (SPN)
+
+Set the following in **Extra** (`auth_type` defaults to `spn` and may be omitted):
+
+```json
+{
+  "tenantId": "<tenant-id>",
+  "clientId": "<client-id>",
+  "clientSecret": "<client-secret>",
+  "auth_type": "spn"
+}
+```
+
+`tenantId` and `clientId` must be valid GUIDs. Create the connection with the
+Airflow CLI:
+
+```bash
+airflow connections add fabric_conn_id \
+  --conn-type microsoft-fabric \
+  --conn-extra '{"tenantId": "<tenant-id>", "clientId": "<client-id>", "clientSecret": "<client-secret>", "auth_type": "spn"}'
+```
+
+#### Pre-minted Access Token
+
+Set `auth_type` to `token` and supply a pre-minted access token along with its
+expiry (epoch seconds). This handler does **not** perform a refresh-token grant;
+when the token is near expiry it re-fetches the connection, expecting a
+[secrets backend](#secrets-backends) to provide a fresh token.
+
+```json
+{
+  "auth_type": "token",
+  "accessToken": "<access-token>",
+  "expiresAt": 1735689600,
+  "expiryBufferSeconds": 300
+}
+```
+
+| Extra key | Required | Description |
+|-----------|----------|-------------|
+| `accessToken` | Yes | Pre-minted bearer token. |
+| `expiresAt` | Yes | Token expiry as epoch seconds. |
+| `expiryBufferSeconds` | No | The secrets backend's cache buffer (seconds); the handler refreshes the token at half this value before expiry. Defaults to 60. |
 
 ## Operators
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,16 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Development Status :: 3 - Alpha",
     "Environment :: Plugins",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules"
 ]
-version = "0.1.2"
-requires-python = ">=3.8"
+version = "0.1.3"
+requires-python = ">=3.10"
 dependencies = [
     "requests",
     "azure-identity",

--- a/src/airflow/providers/microsoft/fabric/hooks/run_item/job.py
+++ b/src/airflow/providers/microsoft/fabric/hooks/run_item/job.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from dataclasses import dataclass, fields
 from typing import Optional, Dict, Any
+import json
 
 from airflow.providers.microsoft.fabric.hooks.connection.rest_connection import MSFabricRestConnection
 from airflow.providers.microsoft.fabric.hooks.run_item.base import BaseFabricRunItemHook, MSFabricRunItemException
@@ -11,7 +12,29 @@ class JobSchedulerConfig(RunItemConfig):
     # API configuration parameters
     api_host: str = "https://api.fabric.microsoft.com"
     api_scope: str = "https://api.fabric.microsoft.com/.default"
+    # Canonical JSON string. Airflow templates this field; with native template
+    # rendering (render_template_as_native_obj=True) a JSON object string is
+    # parsed back into a dict/list, so we normalize it in __post_init__.
     job_params: str = ""
+
+    def __post_init__(self) -> None:
+        self.job_params = self._normalize_job_params(self.job_params)
+
+    @staticmethod
+    def _normalize_job_params(value: Any) -> str:
+        """Coerce ``job_params`` into a canonical JSON string.
+
+        ``job_params`` is an Airflow template field. When native templating is
+        enabled (``render_template_as_native_obj=True``) a JSON object string is
+        evaluated back into a Python ``dict``/``list`` during rendering. This
+        guarantees the hook always sends a valid JSON string and never
+        double-encodes an already-serialized value.
+        """
+        if value is None or value == "":
+            return ""
+        if isinstance(value, str):
+            return value  # already a JSON string; don't re-encode
+        return json.dumps(value)  # dict/list/other -> JSON string
 
     def to_dict(self) -> Dict[str, Any]:
         # Base handles fabric_conn_id/timeout/poll and drops tenacity_retry
@@ -106,12 +129,14 @@ class MSFabricRunJobHook(BaseFabricRunItemHook):
 
         url = self.generate_run_item_api_url(item)
         
-        # send data and content-type = json instead of json= to avoid double encoding
+        # job_params is normalized to a JSON string in JobSchedulerConfig, so send
+        # it as raw data with an explicit Content-Type instead of json= to avoid
+        # double-encoding the already-serialized payload.
         response = await connection.request(
             "POST",
             url,
             self.config.api_scope,
-            data=self.config.job_params,   # JSON string
+            data=self.config.job_params,  # canonical JSON string
             headers={"Content-Type": "application/json"}
         )
 


### PR DESCRIPTION
When running a DAG with render_template_as_native_obj=True, the job_params gets deserialized between initialization and execution.
Also updates the README to match the connection implementation.